### PR TITLE
use `increase-if-necessary` dependabot `versioning-strategy`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       dependencies:
         patterns:
           - "*"
-    versioning-strategy: widen
+    versioning-strategy: increase-if-necessary
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
use `increase-if-necessary` dependabot `versioning-strategy` because pip don't support `widen`.